### PR TITLE
Add checks for existence of window and window.matchMedia before invoking it

### DIFF
--- a/src/matchUserPreference.js
+++ b/src/matchUserPreference.js
@@ -11,6 +11,10 @@ export type UserPreference =
   | 'prefers-reduced-transparency';
 
 const matchUserPreference = (mediaQueryKey: UserPreference, mediaQueryValue: string): ?boolean => {
+  if (!window || !('matchMedia' in window)) {
+    return null;
+  }
+
   const mediaQueryString = `(${mediaQueryKey}: ${mediaQueryValue})`;
   const mediaQuery: MediaQueryList = window.matchMedia(mediaQueryString);
 

--- a/test/matchUserPreference.test.js
+++ b/test/matchUserPreference.test.js
@@ -6,7 +6,7 @@ import mockWindowMatchMedia from '../testing/mockWindowMatchMedia';
 
 describe('matchUserPreference()', () => {
   it('returns true if media query matches', () => {
-    window.matchMedia = jest
+    global.matchMedia = jest
       .fn()
       .mockImplementation(() => mockWindowMatchMedia(true, `(prefers-reduced-motion: reduce)`));
 
@@ -14,7 +14,7 @@ describe('matchUserPreference()', () => {
   });
 
   it('returns false if media query does not match', () => {
-    window.matchMedia = jest
+    global.matchMedia = jest
       .fn()
       .mockImplementation(() => mockWindowMatchMedia(false, `(prefers-reduced-motion: reduce)`));
 
@@ -22,7 +22,7 @@ describe('matchUserPreference()', () => {
   });
 
   it('returns false if media query does not match but media query string matches', () => {
-    window.matchMedia = jest.fn().mockImplementation(() => mockWindowMatchMedia(true, `not all`));
+    global.matchMedia = jest.fn().mockImplementation(() => mockWindowMatchMedia(true, `not all`));
 
     expect(matchUserPreference('prefers-reduced-motion', 'reduce')).toBe(false);
   });

--- a/test/matchUserPreference.test.js
+++ b/test/matchUserPreference.test.js
@@ -5,6 +5,21 @@ import matchUserPreference from '../src';
 import mockWindowMatchMedia from '../testing/mockWindowMatchMedia';
 
 describe('matchUserPreference()', () => {
+  it('returns null if the "window" object does not exist', () => {
+    const originalGlobal = global;
+    global = undefined; // eslint-disable-line no-global-assign
+
+    expect(matchUserPreference('prefers-reduced-motion', 'reduce')).toBe(null);
+
+    global = originalGlobal; // eslint-disable-line no-global-assign
+  });
+
+  it('returns null if the "matchMedia" function does not exist', () => {
+    delete global.matchMedia;
+
+    expect(matchUserPreference('prefers-reduced-motion', 'reduce')).toBe(null);
+  });
+
   it('returns true if media query matches', () => {
     global.matchMedia = jest
       .fn()


### PR DESCRIPTION
As mentioned in #1, this PR adds a check for the existence of window and window.matchMedia before invoking it. I’ve also changed the Jest tests to use the `global` object instead of the `window` object, because Jest uses `global` in its test environment.